### PR TITLE
Fix Expand for path of len <= 1.

### DIFF
--- a/homedir.go
+++ b/homedir.go
@@ -26,11 +26,11 @@ func Dir() (string, error) {
 // is prefixed with `~`. If it isn't prefixed with `~`, the path is
 // returned as-is.
 func Expand(path string) (string, error) {
-	if path[0] != '~' {
+	if len(path) == 0 || path[0] != '~' {
 		return path, nil
 	}
 
-	if path[1] != '/' && path[1] != '\\' {
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
 		return "", errors.New("cannot expand user-specific home dir")
 	}
 

--- a/homedir_test.go
+++ b/homedir_test.go
@@ -44,6 +44,18 @@ func TestExpand(t *testing.T) {
 			fmt.Sprintf("%s/foo", u.HomeDir),
 			false,
 		},
+		
+		{
+			"",
+			"",
+			false,
+		},
+
+		{
+			"~",
+			u.HomeDir,
+			false,
+		},
 
 		{
 			"~foo/foo",


### PR DESCRIPTION
Current implementation panics if `len(path) <= 1`, thus do not produce desired result for single `~` path.
