### PR TITLE
Fixed a bug which would expand string incorrectly under *NIX.

### DIFF
--- a/homedir.go
+++ b/homedir.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -43,7 +44,7 @@ func Expand(path string) (string, error) {
 		return "", err
 	}
 
-	return dir + path[1:], nil
+	return filepath.Join(dir, path[1:]), nil
 }
 
 func dirUnix() (string, error) {


### PR DESCRIPTION
If the home environment varible ended with slash ('/'), the the expanded string
would have two slashes at some point. For detailed information, see the changed unit
tests.
homedir now uses filepath.Join to join the string correctly.