### PR TITLE
Switch from atomic.Value to sync.RWMutex for backward compatibility

### DIFF
--- a/homedir.go
+++ b/homedir.go
@@ -32,6 +32,9 @@ func Dir() (string, error) {
 		}
 	}
 
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+
 	var result string
 	var err error
 	if runtime.GOOS == "windows" {
@@ -44,9 +47,7 @@ func Dir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cacheLock.Lock()
 	homedirCache = result
-	cacheLock.Unlock()
 	return result, nil
 }
 


### PR DESCRIPTION
I wanted to continue to support Go1.2 and 1.3 since those are still the default in distribution repos so switched to sync.RWMutex to maintain thread-safety.  If you don't want this PR, I understand and can continue to use my fork.