### PR TITLE
simplify OS specific homedir detection and some minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Usage is incredibly simple, just call `homedir.Dir()` to get the home directory
 for a user, and `homedir.Expand()` to expand the `~` in a path to the home
 directory.
 
-**Why not just use `os/user`?** The built-in `os/user` package requires
-cgo on Darwin systems. This means that any Go code that uses that package
-cannot cross compile. But 99% of the time the use for `os/user` is just to
-retrieve the home directory, which we can do for the current user without
-cgo. This library does that, enabling cross-compilation.
+**Why not just use `os/user`?** The built-in `os/user` package is not
+available on certain architectures such as i386 or PNaCl. Additionally
+it has a cgo dependency on Darwin systems. This means that any Go code
+that uses that package cannot cross compile. But 99% of the time the
+use for `os/user` is just to retrieve the home directory, which we can
+do for the current user without cgo. This library does that, enabling
+cross-compilation. 

--- a/dir_posix.go
+++ b/dir_posix.go
@@ -1,0 +1,64 @@
+// +build !windows
+
+// Copyright 2016 (C) Mitchell Hashimoto
+// Distributed under the MIT License.
+
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"strings"
+)
+
+// dir returns the homedir of current user for all POSIX compatible
+// operating systems.
+func dir() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// user.Current is not implemented for i386 and PNaCL like environments.
+	if currUser, err := user.Current(); err == nil {
+		return currUser.HomeDir, nil
+	}
+
+	// If that fails, try getent
+	var stdout bytes.Buffer
+	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		// If "getent" is missing, ignore it
+		if err != exec.ErrNotFound {
+			return "", err
+		}
+	} else {
+		if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+			// username:password:uid:gid:gecos:home:shell
+			passwdParts := strings.SplitN(passwd, ":", 7)
+			if len(passwdParts) > 5 {
+				return passwdParts[5], nil
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}

--- a/dir_windows.go
+++ b/dir_windows.go
@@ -1,0 +1,24 @@
+// Copyright 2016 (C) Mitchell Hashimoto
+// Distributed under the MIT License.
+
+package homedir
+
+import (
+	"errors"
+	"os"
+)
+
+// dir returns the homedir of current user for MS Windows OS.
+func dir() (string, error) {
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/homedir.go
+++ b/homedir.go
@@ -1,14 +1,12 @@
+// Copyright 2016 (C) Mitchell Hashimoto
+// Distributed under the MIT License.
+
+// Package homedir implements a portable function to determine current user's homedir.
 package homedir
 
 import (
-	"bytes"
 	"errors"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
 	"sync"
 )
 
@@ -17,37 +15,30 @@ import (
 var DisableCache bool
 
 var homedirCache string
-var cacheLock sync.RWMutex
+var cacheLock sync.Mutex
 
 // Dir returns the home directory for the executing user.
 //
 // This uses an OS-specific method for discovering the home directory.
 // An error is returned if a home directory cannot be detected.
 func Dir() (string, error) {
-	if !DisableCache {
-		cacheLock.RLock()
-		cached := homedirCache
-		cacheLock.RUnlock()
-		if cached != "" {
-			return cached, nil
-		}
-	}
-
 	cacheLock.Lock()
 	defer cacheLock.Unlock()
 
-	var result string
-	var err error
-	if runtime.GOOS == "windows" {
-		result, err = dirWindows()
-	} else {
-		// Unix-like system, so just assume Unix
-		result, err = dirUnix()
+	// Return cached homedir if available.
+	if !DisableCache {
+		if homedirCache != "" {
+			return homedirCache, nil
+		}
 	}
 
+	// Determine OS speific current homedir.
+	result, err := dir()
 	if err != nil {
 		return "", err
 	}
+
+	// Cache for future lookups.
 	homedirCache = result
 	return result, nil
 }
@@ -74,59 +65,4 @@ func Expand(path string) (string, error) {
 	}
 
 	return filepath.Join(dir, path[1:]), nil
-}
-
-func dirUnix() (string, error) {
-	// First prefer the HOME environmental variable
-	if home := os.Getenv("HOME"); home != "" {
-		return home, nil
-	}
-
-	// If that fails, try getent
-	var stdout bytes.Buffer
-	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		// If "getent" is missing, ignore it
-		if err != exec.ErrNotFound {
-			return "", err
-		}
-	} else {
-		if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
-			// username:password:uid:gid:gecos:home:shell
-			passwdParts := strings.SplitN(passwd, ":", 7)
-			if len(passwdParts) > 5 {
-				return passwdParts[5], nil
-			}
-		}
-	}
-
-	// If all else fails, try the shell
-	stdout.Reset()
-	cmd = exec.Command("sh", "-c", "cd && pwd")
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "", err
-	}
-
-	result := strings.TrimSpace(stdout.String())
-	if result == "" {
-		return "", errors.New("blank output when reading home directory")
-	}
-
-	return result, nil
-}
-
-func dirWindows() (string, error) {
-	drive := os.Getenv("HOMEDRIVE")
-	path := os.Getenv("HOMEPATH")
-	home := drive + path
-	if drive == "" || path == "" {
-		home = os.Getenv("USERPROFILE")
-	}
-	if home == "" {
-		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
-	}
-
-	return home, nil
 }

--- a/homedir_test.go
+++ b/homedir_test.go
@@ -30,6 +30,8 @@ func BenchmarkDir(b *testing.B) {
 }
 
 func TestDir(t *testing.T) {
+	// NOTE: This test is not portable. If user.Current() worked
+	// everywhere, we wouldn't need our package in the first place.
 	u, err := user.Current()
 	if err != nil {
 		t.Fatalf("err: %s", err)


### PR DESCRIPTION
* Separated dir code into OS specific files. 
* Since cache is returned right in the beginning and lock is released quickly, regular lock is sufficient. 
* Also added copyright notice and license notice. 