### PR TITLE
Acknowledge and prefer HOME environment variable on Windows

### DIFF
--- a/homedir.go
+++ b/homedir.go
@@ -118,6 +118,11 @@ func dirUnix() (string, error) {
 }
 
 func dirWindows() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
 	drive := os.Getenv("HOMEDRIVE")
 	path := os.Getenv("HOMEPATH")
 	home := drive + path


### PR DESCRIPTION
On Windows, HOME environment variable can be set and should be acknowledged. This would respect the current behaviour of several tools, notably python's.