### PR TITLE
Move OS based implementations behind build flags.

### DIFF
--- a/dir_unix.go
+++ b/dir_unix.go
@@ -1,0 +1,53 @@
+//+build !windows
+
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+func dir() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// If that fails, try getent
+	var stdout bytes.Buffer
+	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		// If "getent" is missing, ignore it
+		if err == exec.ErrNotFound {
+			return "", err
+		}
+	} else {
+		if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+			// username:password:uid:gid:gecos:home:shell
+			passwdParts := strings.SplitN(passwd, ":", 7)
+			if len(passwdParts) > 5 {
+				return passwdParts[5], nil
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = &stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := strings.TrimSpace(stdout.String())
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}

--- a/dir_windows.go
+++ b/dir_windows.go
@@ -1,0 +1,27 @@
+// +build windows
+
+package homedir
+
+import (
+	"errors"
+	"os"
+)
+
+func dir() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	home := drive + path
+	if drive == "" || path == "" {
+		home = os.Getenv("USERPROFILE")
+	}
+	if home == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
+	}
+
+	return home, nil
+}

--- a/homedir.go
+++ b/homedir.go
@@ -1,14 +1,8 @@
 package homedir
 
 import (
-	"bytes"
 	"errors"
-	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
 	"sync"
 )
 
@@ -36,14 +30,7 @@ func Dir() (string, error) {
 	cacheLock.Lock()
 	defer cacheLock.Unlock()
 
-	var result string
-	var err error
-	if runtime.GOOS == "windows" {
-		result, err = dirWindows()
-	} else {
-		// Unix-like system, so just assume Unix
-		result, err = dirUnix()
-	}
+	result, err := dir()
 
 	if err != nil {
 		return "", err
@@ -74,64 +61,4 @@ func Expand(path string) (string, error) {
 	}
 
 	return filepath.Join(dir, path[1:]), nil
-}
-
-func dirUnix() (string, error) {
-	// First prefer the HOME environmental variable
-	if home := os.Getenv("HOME"); home != "" {
-		return home, nil
-	}
-
-	// If that fails, try getent
-	var stdout bytes.Buffer
-	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		// If "getent" is missing, ignore it
-		if err == exec.ErrNotFound {
-			return "", err
-		}
-	} else {
-		if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
-			// username:password:uid:gid:gecos:home:shell
-			passwdParts := strings.SplitN(passwd, ":", 7)
-			if len(passwdParts) > 5 {
-				return passwdParts[5], nil
-			}
-		}
-	}
-
-	// If all else fails, try the shell
-	stdout.Reset()
-	cmd = exec.Command("sh", "-c", "cd && pwd")
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "", err
-	}
-
-	result := strings.TrimSpace(stdout.String())
-	if result == "" {
-		return "", errors.New("blank output when reading home directory")
-	}
-
-	return result, nil
-}
-
-func dirWindows() (string, error) {
-	// First prefer the HOME environmental variable
-	if home := os.Getenv("HOME"); home != "" {
-		return home, nil
-	}
-
-	drive := os.Getenv("HOMEDRIVE")
-	path := os.Getenv("HOMEPATH")
-	home := drive + path
-	if drive == "" || path == "" {
-		home = os.Getenv("USERPROFILE")
-	}
-	if home == "" {
-		return "", errors.New("HOMEDRIVE, HOMEPATH, and USERPROFILE are blank")
-	}
-
-	return home, nil
 }


### PR DESCRIPTION
What
===
Move OS based implementations behind build flags.

Why
===
The fork for choosing the OS based implementation for the home directory
is a runtime fork. Go has build flags and can choose code at
runtime and this is more efficient and results in the library containing
less code.

Note
===
No changes were made to the windows or non-windows implementations. The functions were copied, renamed to `dir()` and then imports were updated to match the usage in each file.