### PR TITLE
Use path/filepath over hardcoded path separators.

### DIFF
--- a/homedir_test.go
+++ b/homedir_test.go
@@ -1,9 +1,9 @@
 package homedir
 
 import (
-	"fmt"
 	"os"
 	"os/user"
+	"path/filepath"
 	"testing"
 )
 
@@ -64,7 +64,7 @@ func TestExpand(t *testing.T) {
 
 		{
 			"~/foo",
-			fmt.Sprintf("%s/foo", u.HomeDir),
+			filepath.Join(u.HomeDir, "foo"),
 			false,
 		},
 
@@ -101,12 +101,12 @@ func TestExpand(t *testing.T) {
 	DisableCache = true
 	defer func() { DisableCache = false }()
 	defer patchEnv("HOME", "/custom/path/")()
-	expected := "/custom/path/foo/bar"
+	expected := filepath.Join("/", "custom", "path", "foo/bar")
 	actual, err := Expand("~/foo/bar")
 
 	if err != nil {
 		t.Errorf("No error is expected, got: %v", err)
-	} else if actual != "/custom/path/foo/bar" {
+	} else if actual != expected {
 		t.Errorf("Expected: %v; actual: %v", expected, actual)
 	}
 }


### PR DESCRIPTION
What
===
Change tests to use `path/filepath` instead of `fmt` and hardcoded `/`
path separators.

Why
===
Joining paths with `/` causes the tests to fail when run on windows because it's file path separator is `\`. Using `path/filepath` allows the code to join paths together using the system path separator without the code needing to know what the separator is.