### PR TITLE
Improve getent fallback

### DIFF
--- a/homedir.go
+++ b/homedir.go
@@ -82,28 +82,40 @@ func dirUnix() (string, error) {
 		return home, nil
 	}
 
-	// If that fails, try getent
 	var stdout bytes.Buffer
-	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		// If the error is ErrNotFound, we ignore it. Otherwise, return it.
-		if err != exec.ErrNotFound {
-			return "", err
+
+	// If that fails, try OS specific commands
+	if runtime.GOOS == "darwin" {
+		cmd := exec.Command("sh", "-c", `dscl -q . -read /Users/"$(whoami)" NFSHomeDirectory | sed 's/^[^ ]*: //'`)
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err == nil {
+			result := strings.TrimSpace(stdout.String())
+			if result != "" {
+				return result, nil
+			}
 		}
 	} else {
-		if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
-			// username:password:uid:gid:gecos:home:shell
-			passwdParts := strings.SplitN(passwd, ":", 7)
-			if len(passwdParts) > 5 {
-				return passwdParts[5], nil
+		cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+		cmd.Stdout = &stdout
+		if err := cmd.Run(); err != nil {
+			// If the error is ErrNotFound, we ignore it. Otherwise, return it.
+			if err != exec.ErrNotFound {
+				return "", err
+			}
+		} else {
+			if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
+				// username:password:uid:gid:gecos:home:shell
+				passwdParts := strings.SplitN(passwd, ":", 7)
+				if len(passwdParts) > 5 {
+					return passwdParts[5], nil
+				}
 			}
 		}
 	}
 
 	// If all else fails, try the shell
 	stdout.Reset()
-	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd := exec.Command("sh", "-c", "cd && pwd")
 	cmd.Stdout = &stdout
 	if err := cmd.Run(); err != nil {
 		return "", err

--- a/homedir_test.go
+++ b/homedir_test.go
@@ -13,7 +13,12 @@ func patchEnv(key, value string) func() {
 		os.Setenv(key, bck)
 	}
 
-	os.Setenv(key, value)
+	if value != "" {
+		os.Setenv(key, value)
+	} else {
+		os.Unsetenv(key)
+	}
+
 	return deferFunc
 }
 
@@ -36,6 +41,18 @@ func TestDir(t *testing.T) {
 	}
 
 	dir, err := Dir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if u.HomeDir != dir {
+		t.Fatalf("%#v != %#v", u.HomeDir, dir)
+	}
+
+	DisableCache = true
+	defer func() { DisableCache = false }()
+	defer patchEnv("HOME", "")()
+	dir, err = Dir()
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}


### PR DESCRIPTION
If HOME is not defined and getent(1) is not found, dirUnix() currently immediately returns an error without even trying the third method (`sh -c 'cd && pwd'`).  It means HOME is the only source for obtaining the home directory on Darwin where getent(1) is missing.

One possible bug here is that the condition to detect if getent(1) is not found might be reversed, which I addressed in the first commit.

The second commit adds a fallback method specially for Darwin.  It is to execute dscl(1) via the shell, so no dependency on cgo will be involved.
