### PR TITLE
Added Plan 9 support

### DIFF
--- a/homedir.go
+++ b/homedir.go
@@ -78,7 +78,14 @@ func Expand(path string) (string, error) {
 
 func dirUnix() (string, error) {
 	// First prefer the HOME environmental variable
-	if home := os.Getenv("HOME"); home != "" {
+	var homeEnv string
+	switch runtime.GOOS {
+		case "plan9":
+			homeEnv = "home"
+		default:
+			homeEnv = "HOME"
+	}
+	if home := os.Getenv(homeEnv); home != "" {
 		return home, nil
 	}
 


### PR DESCRIPTION
Environment variables are lowercase on Plan 9, unlike
the traditional unix system where they're uppercase.

This fixes the check for the "HOME" environment variable
under Plan 9.