### PR TITLE
Use build tags and some other tweaks.

### DIFF
--- a/env_plan9.go
+++ b/env_plan9.go
@@ -1,0 +1,7 @@
+// Package homedir detects the user's home directory without the use of cgo, for use in cross-compilation environments.
+
+// +build plan9
+
+package homedir
+
+const homeEnv = "home"

--- a/env_unix.go
+++ b/env_unix.go
@@ -1,0 +1,7 @@
+// Package homedir detects the user's home directory without the use of cgo, for use in cross-compilation environments.
+
+// +build darwin dragonfly freebsd js,wasm linux nacl netbsd openbsd solaris
+
+package homedir
+
+const homeEnv = "HOME"

--- a/homedir.go
+++ b/homedir.go
@@ -1,19 +1,15 @@
+// Package homedir detects the user's home directory without the use of cgo, for use in cross-compilation environments.
 package homedir
 
 import (
-	"bytes"
 	"errors"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"strconv"
-	"strings"
 	"sync"
 )
 
-// DisableCache will disable caching of the home directory. Caching is enabled
-// by default.
+// DisableCache will disable caching of the home directory.
+// Caching is enabled by default.
 var DisableCache bool
 
 var homedirCache string
@@ -36,25 +32,21 @@ func Dir() (string, error) {
 	cacheLock.Lock()
 	defer cacheLock.Unlock()
 
-	var result string
-	var err error
-	if runtime.GOOS == "windows" {
-		result, err = dirWindows()
-	} else {
-		// Unix-like system, so just assume Unix
-		result, err = dirUnix()
+	if !DisableCache && homedirCache != "" {
+		return homedirCache, nil
 	}
 
+	result, err := dir()
 	if err != nil {
 		return "", err
 	}
+
 	homedirCache = result
 	return result, nil
 }
 
-// Expand expands the path to include the home directory if the path
-// is prefixed with `~`. If it isn't prefixed with `~`, the path is
-// returned as-is.
+// Expand expands the path to include the home directory if the path is prefixed with `~`.
+// If it isn't prefixed with `~`, the path is returned as-is.
 func Expand(path string) (string, error) {
 	if len(path) == 0 {
 		return path, nil
@@ -64,7 +56,11 @@ func Expand(path string) (string, error) {
 		return path, nil
 	}
 
-	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+	if len(path) == 1 {
+		return Dir()
+	}
+
+	if !os.IsPathSeparator(path[1]) {
 		return "", errors.New("cannot expand user-specific home dir")
 	}
 
@@ -73,85 +69,5 @@ func Expand(path string) (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(dir, path[1:]), nil
-}
-
-func dirUnix() (string, error) {
-	homeEnv := "HOME"
-	if runtime.GOOS == "plan9" {
-		// On plan9, env vars are lowercase.
-		homeEnv = "home"
-	}
-
-	// First prefer the HOME environmental variable
-	if home := os.Getenv(homeEnv); home != "" {
-		return home, nil
-	}
-
-	var stdout bytes.Buffer
-
-	// If that fails, try OS specific commands
-	if runtime.GOOS == "darwin" {
-		cmd := exec.Command("sh", "-c", `dscl -q . -read /Users/"$(whoami)" NFSHomeDirectory | sed 's/^[^ ]*: //'`)
-		cmd.Stdout = &stdout
-		if err := cmd.Run(); err == nil {
-			result := strings.TrimSpace(stdout.String())
-			if result != "" {
-				return result, nil
-			}
-		}
-	} else {
-		cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
-		cmd.Stdout = &stdout
-		if err := cmd.Run(); err != nil {
-			// If the error is ErrNotFound, we ignore it. Otherwise, return it.
-			if err != exec.ErrNotFound {
-				return "", err
-			}
-		} else {
-			if passwd := strings.TrimSpace(stdout.String()); passwd != "" {
-				// username:password:uid:gid:gecos:home:shell
-				passwdParts := strings.SplitN(passwd, ":", 7)
-				if len(passwdParts) > 5 {
-					return passwdParts[5], nil
-				}
-			}
-		}
-	}
-
-	// If all else fails, try the shell
-	stdout.Reset()
-	cmd := exec.Command("sh", "-c", "cd && pwd")
-	cmd.Stdout = &stdout
-	if err := cmd.Run(); err != nil {
-		return "", err
-	}
-
-	result := strings.TrimSpace(stdout.String())
-	if result == "" {
-		return "", errors.New("blank output when reading home directory")
-	}
-
-	return result, nil
-}
-
-func dirWindows() (string, error) {
-	// First prefer the HOME environmental variable
-	if home := os.Getenv("HOME"); home != "" {
-		return home, nil
-	}
-
-	// Prefer standard environment variable USERPROFILE
-	if home := os.Getenv("USERPROFILE"); home != "" {
-		return home, nil
-	}
-
-	drive := os.Getenv("HOMEDRIVE")
-	path := os.Getenv("HOMEPATH")
-	home := drive + path
-	if drive == "" || path == "" {
-		return "", errors.New("HOMEDRIVE, HOMEPATH, or USERPROFILE are blank")
-	}
-
-	return home, nil
+	return filepath.Join(dir, path[2:]), nil
 }

--- a/homedir_darwin.go
+++ b/homedir_darwin.go
@@ -1,0 +1,46 @@
+// Package homedir detects the user's home directory without the use of cgo, for use in cross-compilation environments.
+
+// +build darwin
+
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+)
+
+func dir() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv(homeEnv); home != "" {
+		return home, nil
+	}
+
+	stdout := new(bytes.Buffer)
+
+	cmd := exec.Command("sh", "-c", `dscl -q . -read /Users/"$(whoami)" NFSHomeDirectory | sed 's/^[^ ]*: //'`)
+	cmd.Stdout = stdout
+	if err := cmd.Run(); err == nil {
+		result := string(bytes.TrimSpace(stdout.Bytes()))
+		if result != "" {
+			return result, nil
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+
+	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := string(bytes.TrimSpace(stdout.Bytes()))
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}

--- a/homedir_posix.go
+++ b/homedir_posix.go
@@ -1,0 +1,55 @@
+// Package homedir detects the user's home directory without the use of cgo, for use in cross-compilation environments.
+
+// +build dragonfly freebsd js,wasm linux nacl netbsd openbsd solaris plan9
+
+package homedir
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+)
+
+func dir() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv(homeEnv); home != "" {
+		return home, nil
+	}
+
+	stdout := new(bytes.Buffer)
+
+	cmd := exec.Command("getent", "passwd", strconv.Itoa(os.Getuid()))
+	cmd.Stdout = stdout
+	if err := cmd.Run(); err != nil {
+		// If the error is ErrNotFound, we ignore it. Otherwise, return it.
+		if err != exec.ErrNotFound {
+			return "", err
+		}
+	} else {
+		if passwd := bytes.TrimSpace(stdout.Bytes()); len(passwd) > 0 {
+			// username:password:uid:gid:gecos:home:shell
+			passwdParts := bytes.SplitN(passwd, []byte(":"), 7)
+			if len(passwdParts) > 5 {
+				return string(passwdParts[5]), nil
+			}
+		}
+	}
+
+	// If all else fails, try the shell
+	stdout.Reset()
+
+	cmd = exec.Command("sh", "-c", "cd && pwd")
+	cmd.Stdout = stdout
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	result := string(bytes.TrimSpace(stdout.Bytes()))
+	if result == "" {
+		return "", errors.New("blank output when reading home directory")
+	}
+
+	return result, nil
+}

--- a/homedir_test.go
+++ b/homedir_test.go
@@ -122,8 +122,10 @@ func TestExpand(t *testing.T) {
 	actual, err := Expand("~/foo/bar")
 
 	if err != nil {
-		t.Errorf("No error is expected, got: %v", err)
-	} else if actual != expected {
+		t.Fatalf("No error is expected, got: %v", err)
+	}
+
+	if actual != expected {
 		t.Errorf("Expected: %v; actual: %v", expected, actual)
 	}
 }

--- a/homedir_windows.go
+++ b/homedir_windows.go
@@ -1,0 +1,26 @@
+package homedir
+
+import (
+	"errors"
+	"os"
+)
+
+func dir() (string, error) {
+	// First prefer the HOME environmental variable
+	if home := os.Getenv("HOME"); home != "" {
+		return home, nil
+	}
+
+	// Prefer standard environment variable USERPROFILE
+	if home := os.Getenv("USERPROFILE"); home != "" {
+		return home, nil
+	}
+
+	drive := os.Getenv("HOMEDRIVE")
+	path := os.Getenv("HOMEPATH")
+	if drive == "" || path == "" {
+		return "", errors.New("HOMEDRIVE, HOMEPATH, or USERPROFILE are blank")
+	}
+
+	return drive + path, nil
+}


### PR DESCRIPTION
* use build tags rather than dynamically checking `runtime.GOOS`.
* use `os.IsFilePathSeparator`.
* close race condition where after relocking `Dir` does not check to see if there is a cached answer.
* short-circuit `Expand("~")` to `Dir()`.
* do `Split` and `TrimSpace` on bytes rather than strings (minor optimization).
* do not calculate `drive + path` on windows before checking that either is empty (and throwing it away).

Needs multi-OS testing to make sure it does the right thing on windows darwin and plan9, but it does compile for each of those, and the logic should not have changed at all between.