### PR TITLE
Allow paths starting with a tilde

### DIFF
--- a/homedir.go
+++ b/homedir.go
@@ -53,19 +53,16 @@ func Dir() (string, error) {
 }
 
 // Expand expands the path to include the home directory if the path
-// is prefixed with `~`. If it isn't prefixed with `~`, the path is
-// returned as-is.
+// is prefixed with `~/` or is just `~`. Otherwise, the path is
+// returned as-is. An error is returned if the home directory
+// cannot be found.
 func Expand(path string) (string, error) {
 	if len(path) == 0 {
 		return path, nil
 	}
 
-	if path[0] != '~' {
+	if path[0] != '~' || (len(path) > 1 && path[1] != '/' && path[1] != '\\') {
 		return path, nil
-	}
-
-	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
-		return "", errors.New("cannot expand user-specific home dir")
 	}
 
 	dir, err := Dir()

--- a/homedir_test.go
+++ b/homedir_test.go
@@ -99,8 +99,8 @@ func TestExpand(t *testing.T) {
 
 		{
 			"~foo/foo",
-			"",
-			true,
+			"~foo/foo",
+			false,
 		},
 	}
 


### PR DESCRIPTION
Path expansion currently disallows paths starting with `~`.
The `~` character is a valid part of a directory or file name.
A leading `~` is most commonly found in university server paths
where the users have a public web directory, e.g., https://cs.fit.edu/~mmahoney/.

Return the path as-is if the leading `~` is not referring to a
directory name as in `~/` or `~`.